### PR TITLE
Temporarily commenting out pshtt scan

### DIFF
--- a/scan.sh
+++ b/scan.sh
@@ -18,13 +18,13 @@ redis-cli -h orchestrator_redis_1 del gathering_complete
 # Run the https-scan scan
 echo "Running domain-scan scan"
 cd $SHARED_DIR/artifacts/
-/home/scanner/domain-scan/scan $SHARED_DIR/artifacts/scanme.csv --scan=pshtt --lambda --lambda-details --debug --meta --cache --workers=550
+# /home/scanner/domain-scan/scan $SHARED_DIR/artifacts/scanme.csv --scan=pshtt --lambda --lambda-details --debug --meta --cache --workers=550
 # domain-scan removes all existing CSV result files before starting a
 # new scan, so we need to stash the pshtt results in a safe place
-mv $SHARED_DIR/artifacts/results/pshtt.csv $SHARED_DIR/artifacts/pshtt.csv
+# mv $SHARED_DIR/artifacts/results/pshtt.csv $SHARED_DIR/artifacts/pshtt.csv
 /home/scanner/domain-scan/scan $SHARED_DIR/artifacts/scanme.csv --scan=trustymail,sslyze --debug --meta --cache --workers=50
 # Now put the pshtt results back
-mv $SHARED_DIR/artifacts/pshtt.csv $SHARED_DIR/artifacts/results/pshtt.csv
+# mv $SHARED_DIR/artifacts/pshtt.csv $SHARED_DIR/artifacts/results/pshtt.csv
 
 # Clean up files no longer needed
 rm -rf $SHARED_DIR/artifacts/cache


### PR DESCRIPTION
Temporarily commenting out pshtt scan, since we want to generate the https reports using the old containers for another week.